### PR TITLE
Add darwin arm64 compilation target

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         goos: [linux, windows, darwin]
         goarch: [amd64]
+        include:
+          - goos: darwin
+            goarch: arm64
             
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
Hi 👋 

Due to lack of mac arm64 (ie M1, M2) compilation target, I can’t install https://github.com/CadQuery/CQ-editor hence the PR.

Thanks in advance for taking a look!